### PR TITLE
更改冗长的base64url为blobUrl;更新README.md增强可读性

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,20 @@
 
 使用npm安装
 
+```js
 npm install vue-watermark-directive --save
+```
+
+使用yarn安装
+```js
+yarn add vue-watermark-directive --save
+```
 
 ### 使用
 
 在应用初始化时，安装插件。
 
-```
+```js
 import Vue from 'vue'
 import watermark from 'vue-watermark-directive'
 
@@ -19,7 +26,7 @@ Vue.use(watermark)
 
 这里也支持使用第二个参数来配置插件。
 
-```
+```js
 import Vue from 'vue'
 import vueWatermark from 'vue-watermark-directive'
 
@@ -44,7 +51,7 @@ Vue.use(vueWatermark, DEFAULT_CONFIG)
 
 使用字符串：
 
-```
+```html
 <div
   class="container"
   v-watermark="'ABC'">
@@ -53,7 +60,7 @@ Vue.use(vueWatermark, DEFAULT_CONFIG)
 
 使用自定义配置:
 
-```
+```html
 <div
   class="container"
   v-watermark="{

--- a/src/watermark.js
+++ b/src/watermark.js
@@ -1,4 +1,4 @@
-function drawWatermark({
+async function drawWatermark({
   container = document.body,
   zIndex = 1000,
   font = '16px microsoft yahei',
@@ -26,7 +26,21 @@ function drawWatermark({
   ctx.rotate(Math.PI / 180 * rotate)
   ctx.fillText(content, width / 2, 0)
 
-  let base64Url = canvas.toDataURL()
+  function getBlobUrl(icanvas) {
+    return new Promise((resolve) => {
+      icanvas.toBlob((blob) => {
+        resolve(URL.createObjectURL(blob))
+      })
+    })
+  }
+  const urlMark = `vue-watermark-blob-url-${content}`
+  if (sessionStorage.getItem(urlMark)) {
+    URL.revokeObjectURL(sessionStorage.getItem(urlMark))
+    sessionStorage.removeItem(urlMark)
+  }
+  const blobUrl = await getBlobUrl(canvas)
+  sessionStorage.setItem(urlMark, blobUrl)
+
   let prevWatermarkDiv = container.firstChild
   let watermarkDiv
 
@@ -48,7 +62,7 @@ function drawWatermark({
       z-index: ${zIndex};
       pointer-events: none;
       background-repeat: ${repeat ? 'repeat' : 'no-repeat'};
-      background-image: url('${base64Url}');
+      background-image: url('${blobUrl}');
     `
   )
 


### PR DESCRIPTION
当canvas转换成base64字符串后，长度时非常长的，当长度超出一定范围后，浏览器会报错。
更新README.md增强可读性。